### PR TITLE
add new Instagram mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const handleRequest = (details) => {
                 formData.hasOwnProperty("fb_api_req_friendly_name")
                 && (
                     formData.fb_api_req_friendly_name.includes("PolarisAPIReelSeenMutation")
+                    || formData.fb_api_req_friendly_name.includes("PolarisAPIReelSeenDirectMutation")
                     || formData.fb_api_req_friendly_name.includes("storiesUpdateSeenStateMutation")
                     || formData.fb_api_req_friendly_name.includes("usePolarisStoriesV3SeenMutation")
                     || formData.fb_api_req_friendly_name.includes("PolarisStoriesV3SeenMutation")

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const handleRequest = (details) => {
                     || formData.fb_api_req_friendly_name.includes("storiesUpdateSeenStateMutation")
                     || formData.fb_api_req_friendly_name.includes("usePolarisStoriesV3SeenMutation")
                     || formData.fb_api_req_friendly_name.includes("PolarisStoriesV3SeenMutation")
+                    || formData.fb_api_req_friendly_name.includes("PolarisStoriesV3SeenDirectMutation")
                 )
             ) {
                 cancel = true;


### PR DESCRIPTION
Add two new mutations used by Instagram

- `PolarisAPIReelSeenDirectMutation`: used when viewing stories from the main page
- `PolarisStoriesV3SeenDirectMutation`: used when viewing stories from the user profile page

Close #12 